### PR TITLE
Fix import path for bitcask

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ err = ifchanged.NewIf().
 `ifchanged`, additionally, has a way to provide checksums using a `DB` interface.
 
 * `linetuple.go` contains a simple file-based implementation of `DB` (not really optimised yet)
-* [github.com/prologic/bitcask](github.com/prologic/bitcask) implements it.
+* [git.mills.io/prologic/bitcask](git.mills.io/prologic/bitcask) implements it.

--- a/bitcask.go
+++ b/bitcask.go
@@ -1,6 +1,6 @@
 package ifchanged
 
-//import "github.com/prologic/bitcask"
+//import "git.mills.io/prologic/bitcask"
 
 // Bitcask auto-implements ifchanged.DB interface, no need to write anything
 //type DBBitcask bitcask.Bitcask


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇